### PR TITLE
Rudimentary support for mi_media_detect_type on FreeBSD.

### DIFF
--- a/utils/common/media-info.cpp
+++ b/utils/common/media-info.cpp
@@ -17,6 +17,10 @@
 #include <linux/media.h>
 
 #include <media-info.h>
+#ifndef __linux__
+#include <linux/videodev2.h>
+#include <fcntl.h>
+#endif
 
 static std::string num2s(unsigned num, bool is_hex = true)
 {
@@ -54,7 +58,7 @@ media_type mi_media_detect_type(const char *device)
 
 	if (stat(device, &sb) == -1)
 		return MEDIA_TYPE_CANT_STAT;
-
+#ifdef __linux__
 	std::string uevent_path("/sys/dev/char/");
 
 	uevent_path += num2s(major(sb.st_rdev), false) + ":" +
@@ -90,6 +94,22 @@ media_type mi_media_detect_type(const char *device)
 	}
 
 	uevent_file.close();
+#else // Not Linux
+	int fd = open(device, O_RDONLY);
+	if (fd >= 0) {
+		struct v4l2_capability caps;
+		if (ioctl(fd, VIDIOC_QUERYCAP, &caps) == 0) {
+			if (caps.device_caps & V4L2_CAP_VIDEO_CAPTURE) {
+				return MEDIA_TYPE_VIDEO;
+			} else if (caps.device_caps & V4L2_CAP_VBI_CAPTURE) {
+				return MEDIA_TYPE_VBI;
+			} else if (caps.device_caps & V4L2_CAP_RADIO) {
+				return MEDIA_TYPE_RADIO;
+			}
+		}
+		close(fd);
+	}
+#endif
 	return MEDIA_TYPE_UNKNOWN;
 }
 


### PR DESCRIPTION
FreeBSD doesn't have the same uevent and sys filesystem that Linux
does. So, use the VIDIOC_QUERYCAP to find out basic capabilities for a
device. The ioctl doesn't give us as much information, but it gets
things like webcams, VBIs, and radios. This is better than what was
there previously, which was returning unknown.

This lets some v4l-utils like v4l2-ctl a little more useful.